### PR TITLE
Skia diet

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
-SKIA_ARGS='is_official_build=true skia_use_egl=true skia_use_libwebp_decode=false skia_use_libwebp_encode=false skia_enable_pdf=false skia_enable_skottie=false skia_enable_svg=false'
+SKIA_ARGS='is_official_build=true skia_use_egl=true skia_use_libwebp_decode=false skia_use_libwebp_encode=false skia_enable_pdf=false skia_enable_skottie=false skia_enable_svg=false skia_use_dng_sdk=false skia_use_wuffs=false'
 
 build-skia: bin/gn
 	cd skia && bin/gn gen out/Static --args=$(SKIA_ARGS)
 	ninja -C skia/out/Static
 
 bin/gn:
-	cd skia && GIT_SYNC_DEPS_SKIP_EMSDK=1 python3 tools/git-sync-deps
+	cd skia && bin/fetch-gn

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-SKIA_ARGS='is_official_build=true skia_use_egl=true skia_use_libwebp_decode=false skia_use_libwebp_encode=false skia_enable_pdf=false skia_enable_skottie=false skia_enable_svg=false skia_use_dng_sdk=false skia_use_wuffs=false'
+SKIA_ARGS='is_official_build=true skia_use_egl=true skia_use_libwebp_decode=false skia_use_libwebp_encode=false skia_enable_pdf=false skia_enable_skottie=false skia_enable_svg=false skia_use_dng_sdk=false skia_use_wuffs=false skia_use_xps=false skia_use_system_expat=true skia_enable_fontmgr_android=false'
 
 build-skia: bin/gn
 	cd skia && bin/gn gen out/Static --args=$(SKIA_ARGS)

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Additionally, since it uses Skia, you need to build Skia first.
 To build Skia, follow the below commands.
 
 ```sh
-$ git submodule update --init --recursive
+$ git submodule update --init --recursive --depth 1
 $ make build-skia
 ```
 


### PR DESCRIPTION
Skip external third party libraries fetching in Skia.

`tools/git-sync-deps` downloads a massive code which is not required for niminal Skia build.